### PR TITLE
Should Allow Heroku CI To Run Tests

### DIFF
--- a/app.json
+++ b/app.json
@@ -59,7 +59,7 @@
           }
         },
         "scripts": {
-          "test": "python manage.py test"
+          "test": "cd backend && python manage.py test"
         }
       }
     }


### PR DESCRIPTION
Changed test script to `cd backend && python manage.py test`, so that Heroku can find the tests.