### PR TITLE
About page button fix

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,13 +1,24 @@
-import { Metadata } from "next";
+"use client";
+
+import { auth } from "@/app/firebase/firebaseConfig";
+import { User } from "firebase/auth";
+import { useEffect, useState } from "react";
+import Link from "next/link";
 import Image from "next/image";
 
-export const metadata: Metadata = {
-  title:
-    "Next.js E-commerce Dashboard | TailAdmin - Next.js Dashboard Template",
-  description: "This is Next.js Home for TailAdmin Dashboard Template",
-};
-
 export default function About() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((currentUser) => {
+      setUser(currentUser);
+      setLoaded(true);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
   return (
     <div className="ml-20 mr-20 mt-4 grid grid-cols-1 gap-4 md:mt-6 md:grid-cols-12 md:gap-6 2xl:mt-7.5 2xl:gap-7.5">
       <div id="left-col" className="rounded-2xl md:col-span-6">
@@ -29,9 +40,25 @@ export default function About() {
           making specific recommendations, empowering you to make decisions in
           line with your values.
         </p>
-        <button className="mt-5 w-1/3 rounded-2xl border border-stroke bg-green-400 px-5 pb-3 pt-3 font-bold text-white sm:px-7.5 xl:col-span-8">
-          SIGN IN
-        </button>
+        {loaded ? (
+          user ? (
+            <Link href="/dashboard">
+              <button className="mt-4 rounded-lg bg-green-500 px-8 py-3 font-bold text-white transition duration-200 hover:bg-green-600">
+                DASHBOARD
+              </button>
+            </Link>
+          ) : (
+            <Link href="/main-site/auth/SignInWithGoogle">
+              <button className="mt-4 rounded-lg bg-green-500 px-8 py-3 font-bold text-white transition duration-200 hover:bg-green-600">
+                SIGN IN
+              </button>
+            </Link>
+          )
+        ) : (
+          <button className="mt-4 rounded-lg bg-green-500 px-8 py-3 font-bold text-white transition duration-200 hover:bg-green-600">
+            Loading...
+          </button>
+        )}
       </div>
       <div
         id="right-col"


### PR DESCRIPTION
Fixed error where the about page previously linkedin to the dashboard whether the user was logged in or not. When the user is logged out, the section of the about page looks like this:
<img width="598" alt="Screen Shot 2024-11-23 at 2 43 30 AM" src="https://github.com/user-attachments/assets/158da910-3abb-4149-91a7-3213e704a0f5">

When the user is logged in, the section looks like this:
<img width="584" alt="Screen Shot 2024-11-23 at 2 44 37 AM" src="https://github.com/user-attachments/assets/f6200171-a9a3-4b0d-a88c-0f8e105c63c5">

When the front-end hasn't yet got a response from Firebase of whether the user is logged in, the section looks like this:
<img width="587" alt="Screen Shot 2024-11-23 at 2 44 49 AM" src="https://github.com/user-attachments/assets/98e1aaa2-c08c-4c88-92f1-b1a35747661d">